### PR TITLE
Multiple improvements

### DIFF
--- a/Claudable.sln
+++ b/Claudable.sln
@@ -5,8 +5,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Claudable", "Claudable\Claudable.csproj", "{4E38DD41-07A8-42F6-A614-8990DC888970}"
 EndProject
 Global
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {BE2AB5EF-762E-4773-9795-22F4645A4091}
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{4E38DD41-07A8-42F6-A614-8990DC888970}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -14,13 +15,10 @@ Global
 		{4E38DD41-07A8-42F6-A614-8990DC888970}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4E38DD41-07A8-42F6-A614-8990DC888970}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-EndGlobal
-
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BE2AB5EF-762E-4773-9795-22F4645A4091}
+	EndGlobalSection
 EndGlobal

--- a/Claudable/ClaudeTheme.xaml
+++ b/Claudable/ClaudeTheme.xaml
@@ -333,102 +333,115 @@
                 <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
             </Style>
         </HierarchicalDataTemplate.ItemContainerStyle>
-        <Grid>
+        <Grid Margin="0" MinHeight="24">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto" SharedSizeGroup="Icon"/>
+                <ColumnDefinition Width="Auto" SharedSizeGroup="SyncState"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
-            <controls:FileSystemIcon Grid.Column="1" Path="{Binding FullPath}" Width="16" Height="16" Margin="0,0,5,0"/>
-            <TextBlock Grid.Column="2" Text="{Binding Name}" Foreground="{StaticResource ClaudeTextBrush}"/>
             <!-- Refresh Button -->
-            <Button Grid.Column="0" Background="PaleGoldenrod"
+            <Button Grid.Column="0" 
+                    Background="PaleGoldenrod"
                     Style="{StaticResource SmallButtonStyle}"
                     Command="{Binding Path=RefreshArtifactsCommand, Source={x:Static claudable:MainWindow.MainViewModel}}"
                     CommandParameter="{Binding}"
-                    Width="14"
-                    Height="14"
+                    Width="14" Height="14"
                     BorderThickness="0"
                     Padding="0,-4,0,0"
-                    Margin="0,0,0,0"
                     HorizontalContentAlignment="Center"
                     VerticalContentAlignment="Center"
                     ToolTip="Refresh outdated artifacts in this folder"
-                    Visibility="{Binding HasOutdatedFiles, Converter={StaticResource BooleanToVisibilityConverter}}"
-                    >
+                    Visibility="{Binding HasOutdatedFiles, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBlock Text="⟳" Foreground="Black"/>
             </Button>
+
+            <controls:FileSystemIcon Grid.Column="1" 
+                                    Path="{Binding FullPath}" 
+                                    Width="16" Height="16" 
+                                    Margin="2,0"/>
+                               
+            <TextBlock Grid.Column="2" 
+                       Text="{Binding Name}" 
+                       Foreground="{StaticResource ClaudeTextBrush}" 
+                       VerticalAlignment="Center"/>
         </Grid>
     </HierarchicalDataTemplate>
 
     <!-- Project File Item Template -->
     <DataTemplate DataType="{x:Type vm:ProjectFile}">
-        <Grid Margin="2" Height="20" HorizontalAlignment="Stretch" Grid.IsSharedSizeScope="True" 
-          Background="Transparent" >
-            <Grid.ToolTip>
-                <StackPanel Orientation="Vertical" Margin="2">
-                    <StackPanel Orientation="Horizontal" Margin="2">
-                        <TextBlock Text="   Local: " FontSize="10" Foreground="{StaticResource ClaudeSecondaryBrush}"/>
-                        <TextBlock Text="{Binding LocalLastModified, StringFormat={}{0:g}}" FontSize="10" 
-                             Foreground="{StaticResource ClaudeSecondaryBrush}" Margin="0,0,10,0"/>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal" Margin="2">
-                        <TextBlock Text="Artifact: " FontSize="10" Foreground="{StaticResource ClaudeSecondaryBrush}"/>
-                        <TextBlock Text="{Binding ArtifactLastModified, StringFormat={}{0:g}}" FontSize="10" 
-                             Foreground="{StaticResource ClaudeSecondaryBrush}"/>
-                    </StackPanel>
-                </StackPanel>
-            </Grid.ToolTip>
+        <Grid Margin="0" MinHeight="24" HorizontalAlignment="Stretch" Background="Transparent">
             <Grid.InputBindings>
                 <MouseBinding Gesture="LeftDoubleClick" 
-                          Command="{Binding DataContext.DoubleClickTrackedArtifactCommand, 
-                                    RelativeSource={RelativeSource AncestorType=Window}}"
-                          CommandParameter="{Binding}"/>
+                             Command="{Binding DataContext.DoubleClickTrackedArtifactCommand, 
+                                       RelativeSource={RelativeSource AncestorType=Window}}"
+                             CommandParameter="{Binding}"/>
             </Grid.InputBindings>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="Icon"/>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="SyncState"/>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="Status"/>
-                <ColumnDefinition Width="*" MinWidth="200" SharedSizeGroup="FileName"/>
+                <ColumnDefinition Width="*" MinWidth="100"/>
                 <ColumnDefinition Width="Auto" SharedSizeGroup="TrackButton"/>
             </Grid.ColumnDefinitions>
 
-            <controls:FileSystemIcon Grid.Column="2" Path="{Binding FullPath}" Width="16" Height="16"/>
-
-            <TextBlock Grid.Column="3" Text="{Binding Name}" VerticalAlignment="Center" HorizontalAlignment="Stretch"/>
-
-            <Border Grid.Column="0" Grid.ColumnSpan="2" Width="34"/>
-
-            <Border Grid.Column="0" CornerRadius="4" Width="16" Height="16"
-                Background="{Binding IsLocalNewer, Converter={StaticResource BoolToColorConverter}}"
-                Visibility="{Binding IsTrackedAsArtifact, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <!-- Sync Status -->
+            <Border Grid.Column="0" Width="14" Height="14" Margin="0,0,2,0"
+                    CornerRadius="2"
+                    Background="{Binding IsLocalNewer, Converter={StaticResource BoolToColorConverter}}"
+                    Visibility="{Binding IsTrackedAsArtifact, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBlock Text="{Binding IsLocalNewer, Converter={StaticResource UploadOrDownload}}" 
-                       FontSize="16" Foreground="{StaticResource ClaudeTextBrush}" 
-                       Margin="0,-4,0,0"
-                       HorizontalAlignment="Center"/>
-            </Border>
-            <Border Grid.Column="1" CornerRadius="4" Width="16"  Height="16"
-                Background="{StaticResource ClaudeHighlightBrush}"
-                Visibility="{Binding IsTrackedAsArtifact, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <TextBlock Text="A" FontSize="10" Foreground="{StaticResource ClaudeTextBrush}" HorizontalAlignment="Center"/>
+                           FontSize="10" 
+                           Foreground="{StaticResource ClaudeTextBrush}"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"/>
             </Border>
 
-            <!-- Track Button -->
-            <Button Grid.Column="4" Content="Track" 
-                Command="{Binding TrackArtifactCommand}"
-                Visibility="{Binding IsTrackedAsArtifact, 
-                           Converter={StaticResource InverseBooleanToVisibilityConverter}}"
-                Style="{StaticResource SmallButtonStyle}"
-                Margin="0,0,4,0"/>
+            <!-- Artifact Status -->
+            <Border Grid.Column="1" 
+                    Width="14" Height="14"
+                    CornerRadius="2"
+                    Background="{StaticResource ClaudeHighlightBrush}"
+                    Visibility="{Binding IsTrackedAsArtifact, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <TextBlock Text="A" 
+                           FontSize="10" 
+                           Foreground="{StaticResource ClaudeTextBrush}" 
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"/>
+            </Border>
 
-            <!-- Untrack Button -->
-            <Button Grid.Column="4" Content="Untrack" 
-                Command="{Binding UntrackArtifactCommand}"
-                Visibility="{Binding IsTrackedAsArtifact, 
-                           Converter={StaticResource BooleanToVisibilityConverter}}"
-                Style="{StaticResource SmallButtonStyle}"/>
+            <!-- File Icon -->
+            <controls:FileSystemIcon Grid.Column="2" 
+                                    Path="{Binding FullPath}" 
+                                    Width="16" Height="16" 
+                                    Margin="2,0"/>
+
+            <!-- Filename -->
+            <TextBlock Grid.Column="3" 
+                       Text="{Binding Name}" 
+                       VerticalAlignment="Center"/>
+
+            <!-- Track/Untrack Button -->
+            <Button Grid.Column="4" 
+                    Content="Track" 
+                    Command="{Binding TrackArtifactCommand}"
+                    Visibility="{Binding IsTrackedAsArtifact, 
+                               Converter={StaticResource InverseBooleanToVisibilityConverter}}"
+                    Style="{StaticResource SmallButtonStyle}"
+                    Padding="4,0"
+                    Height="18"
+                    Margin="4,0"/>
+
+            <Button Grid.Column="4" 
+                    Content="Untrack" 
+                    Command="{Binding UntrackArtifactCommand}"
+                    Visibility="{Binding IsTrackedAsArtifact, 
+                               Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Style="{StaticResource SmallButtonStyle}"
+                    Padding="4,0"
+                    Height="18"
+                    Margin="4,0"/>
         </Grid>
     </DataTemplate>
 

--- a/Claudable/Extensions/TreeViewStateExtensions.cs
+++ b/Claudable/Extensions/TreeViewStateExtensions.cs
@@ -1,0 +1,54 @@
+﻿namespace Claudable.Extensions
+{
+    using ViewModels;
+
+    public static class TreeViewStateExtensions
+    {
+        public static string[] GetExpandedPaths(this ProjectFolder rootFolder)
+        {
+            var expandedPaths = new List<string>();
+            CollectExpandedPaths(rootFolder, expandedPaths);
+            return expandedPaths.ToArray();
+        }
+
+        private static void CollectExpandedPaths(ProjectFolder folder, List<string> expandedPaths)
+        {
+            if (folder.IsExpanded)
+            {
+                expandedPaths.Add(folder.FullPath);
+            }
+
+            foreach (var child in folder.Children)
+            {
+                if (child is ProjectFolder childFolder)
+                {
+                    CollectExpandedPaths(childFolder, expandedPaths);
+                }
+            }
+        }
+
+        public static void RestoreExpandedState(this ProjectFolder rootFolder, string[] expandedPaths)
+        {
+            if (expandedPaths == null || expandedPaths.Length == 0)
+            {
+                return;
+            }
+
+            var expandedPathsSet = new HashSet<string>(expandedPaths);
+            RestoreExpandedStateRecursive(rootFolder, expandedPathsSet);
+        }
+
+        private static void RestoreExpandedStateRecursive(ProjectFolder folder, HashSet<string> expandedPaths)
+        {
+            folder.IsExpanded = expandedPaths.Contains(folder.FullPath);
+
+            foreach (var child in folder.Children)
+            {
+                if (child is ProjectFolder childFolder)
+                {
+                    RestoreExpandedStateRecursive(childFolder, expandedPaths);
+                }
+            }
+        }
+    }
+}

--- a/Claudable/MainWindow.xaml
+++ b/Claudable/MainWindow.xaml
@@ -201,13 +201,17 @@
 
                                     <TextBlock Text="Project Structure" FontWeight="Bold" Margin="0,0,0,5"/>
 
-
-                                    <TreeView x:Name="ProjectStructureTreeView" Grid.Row="1" ItemsSource="{Binding RootProjectFolder.FilteredChildren}"
-                                                  AllowDrop="True"
-                                                  Drop="ProjectFolder_Drop"
-                                                  PreviewMouseLeftButtonDown="TreeView_PreviewMouseLeftButtonDown"
-                                                  MouseMove="TreeView_MouseMove"
-                                                  >
+                                    <TreeView x:Name="ProjectStructureTreeView"
+                                              Grid.Row="1"
+                                              ItemsSource="{Binding RootProjectFolder.FilteredChildren}"
+                                              VirtualizingStackPanel.IsVirtualizing="True"
+                                              VirtualizingStackPanel.VirtualizationMode="Recycling"
+                                              ScrollViewer.IsDeferredScrollingEnabled="True"
+                                              ScrollViewer.CanContentScroll="True"
+                                              AllowDrop="True"
+                                              Drop="ProjectFolder_Drop"
+                                              PreviewMouseLeftButtonDown="TreeView_PreviewMouseLeftButtonDown"
+                                              MouseMove="TreeView_MouseMove">
                                         <TreeView.ItemContainerStyle>
                                             <Style TargetType="{x:Type TreeViewItem}">
                                                 <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
@@ -215,6 +219,8 @@
                                                 <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
                                                 <Setter Property="FontWeight" Value="Normal" />
                                                 <Setter Property="AllowDrop" Value="True" />
+                                                <Setter Property="VirtualizingStackPanel.IsVirtualizing" Value="True" />
+                                                <Setter Property="VirtualizingStackPanel.VirtualizationMode" Value="Recycling" />
                                                 <Style.Triggers>
                                                     <Trigger Property="IsSelected" Value="True">
                                                         <Setter Property="FontWeight" Value="Bold" />

--- a/Claudable/MainWindow.xaml
+++ b/Claudable/MainWindow.xaml
@@ -120,7 +120,7 @@
                                                 <ListBox.ItemTemplate>
                                                     <DataTemplate>
                                                         <Grid >
-                                                            <TextBlock Text="{Binding}" Margin="0,0,10,0" HorizontalAlignment="Left"/>
+                                                            <TextBlock Text="{Binding Value}" Margin="0,0,10,0" HorizontalAlignment="Left"/>
                                                             <Button Content="Remove"  HorizontalAlignment="Right"
                                                         Command="{Binding DataContext.FilterViewModel.RemoveFilterCommand, 
                                                                           RelativeSource={RelativeSource AncestorType=Window}}"

--- a/Claudable/Models/AppState.cs
+++ b/Claudable/Models/AppState.cs
@@ -5,6 +5,7 @@
         public bool IsPanelsSwapped { get; set; }
         public int SelectedTabIndex { get; set; }
         public string[] Filters { get; set; }
+        public string[] ExpandedFolders { get; set; }
         public string ProjectRootPath { get; set; }
         public FilterMode CurrentFilterMode { get; internal set; }
     }

--- a/Claudable/Models/Filter.cs
+++ b/Claudable/Models/Filter.cs
@@ -12,7 +12,6 @@
 
         public string Value { get; set; }
     
-        [JsonIgnore]
         public bool ShouldPrependProjectFolder => FilterViewModel.FolderChar.Contains(Value[0]);
     }
 }

--- a/Claudable/Models/Filter.cs
+++ b/Claudable/Models/Filter.cs
@@ -1,0 +1,18 @@
+﻿namespace Claudable.Models
+{
+    using System.Text.Json.Serialization;
+    using ViewModels;
+
+    public class Filter
+    {
+        public Filter(string filterValue)
+        {
+            Value = filterValue;
+        }
+
+        public string Value { get; set; }
+    
+        [JsonIgnore]
+        public bool ShouldPrependProjectFolder => FilterViewModel.FolderChar.Contains(Value[0]);
+    }
+}

--- a/Claudable/ViewModels/FilterViewModel.cs
+++ b/Claudable/ViewModels/FilterViewModel.cs
@@ -5,12 +5,16 @@ using System.Windows.Input;
 
 namespace Claudable.ViewModels
 {
-    public class FilterViewModel : INotifyPropertyChanged
+  using Models;
+
+  public class FilterViewModel : INotifyPropertyChanged
     {
+        public static readonly char[] FolderChar = ['/', '\\'];
+
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private ObservableCollection<string> _filters;
-        public ObservableCollection<string> Filters
+        private ObservableCollection<Filter> _filters;
+        public ObservableCollection<Filter> Filters
         {
             get => _filters;
             set
@@ -36,26 +40,30 @@ namespace Claudable.ViewModels
 
         public FilterViewModel()
         {
-            Filters = new ObservableCollection<string>();
-            AddFilterCommand = new RelayCommand(AddFilter, CanAddFilter);
-            RemoveFilterCommand = new RelayCommand<string>(RemoveFilter);
+            Filters             = new ObservableCollection<Filter>();
+            AddFilterCommand    = new RelayCommand(AddFilter, CanAddFilter);
+            RemoveFilterCommand = new RelayCommand<Filter>(RemoveFilter);
         }
 
         private bool CanAddFilter()
         {
-            return !string.IsNullOrWhiteSpace(NewFilter);
+            return !string.IsNullOrWhiteSpace(NewFilter) && !(NewFilter.Length == 1 && FolderChar.Any(fc => fc == NewFilter[0]));
         }
 
         private void AddFilter()
         {
             if (CanAddFilter())
             {
-                Filters.Add(NewFilter.Trim());
+                var filterValue = NewFilter.Trim().Replace('/', '\\');
+
+                var newFilter = new Filter(filterValue);
+
+                Filters.Add(newFilter);
                 NewFilter = string.Empty;
             }
         }
 
-        private void RemoveFilter(string filter)
+        private void RemoveFilter(Filter filter)
         {
             Filters.Remove(filter);
         }

--- a/Claudable/ViewModels/MainViewModel.cs
+++ b/Claudable/ViewModels/MainViewModel.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Input;
@@ -206,11 +207,20 @@ namespace Claudable.ViewModels
 
         private bool UpdateProjectStructureRecursive(ProjectFolder folder)
         {
-            bool hasChanges = false;
-            var currentItems = new HashSet<string>(folder.Children.Select(c => c.FullPath));
+            bool ShouldExcludeEntry(Filter filter, string filePath)
+            {
+                var filterValue = filter.ShouldPrependProjectFolder
+                    ? $"{RootProjectFolder.FullPath}{filter.Value}"
+                    : filter.Value;
+
+                return filePath.IndexOf(filterValue, StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+
+            bool hasChanges   = false;
+            var  currentItems = new HashSet<string>(folder.Children.Select(c => c.FullPath));
+
             var entries = Directory.EnumerateFileSystemEntries(folder.FullPath)
-                .Where(filePath => !FilterViewModel.Filters.Any(filter =>
-                    filePath.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0));
+                                   .Where(filePath => !FilterViewModel.Filters.Any(filter => ShouldExcludeEntry(filter, filePath)));
 
             var directoryItems = new HashSet<string>(entries);
 
@@ -512,7 +522,7 @@ namespace Claudable.ViewModels
             {
                 IsPanelsSwapped = IsPanelsSwapped,
                 SelectedTabIndex = SelectedTabIndex,
-                Filters = FilterViewModel.Filters.ToArray(),
+                Filters = FilterViewModel.Filters.Select(f => f.Value).ToArray(),
                 ProjectRootPath = RootProjectFolder?.FullPath,
                 CurrentFilterMode = CurrentFilterMode
             };
@@ -536,7 +546,7 @@ namespace Claudable.ViewModels
 
                 IsPanelsSwapped = state.IsPanelsSwapped;
                 SelectedTabIndex = state.SelectedTabIndex;
-                FilterViewModel.Filters = new ObservableCollection<string>(state.Filters ?? Array.Empty<string>());
+                FilterViewModel.Filters = new ObservableCollection<Filter>(state.Filters.Any() ? state.Filters.Select(f => new Filter(f)) : Array.Empty<Filter>());
                 CurrentFilterMode = state.CurrentFilterMode;
 
                 if (!string.IsNullOrEmpty(state.ProjectRootPath))

--- a/Claudable/ViewModels/MainViewModel.cs
+++ b/Claudable/ViewModels/MainViewModel.cs
@@ -1,3 +1,4 @@
+using Claudable.Extensions;
 using Claudable.Models;
 using Claudable.Services;
 using Claudable.Utilities;
@@ -7,7 +8,6 @@ using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Input;
@@ -263,7 +263,8 @@ namespace Claudable.ViewModels
 
                 _pathCache.TryAdd(itemPath, newItem);
                 hasChanges = true;
-                ExpandToItem(newItem);
+                
+                //ExpandToItem(newItem);
             }
 
             // Recursively update existing subfolders
@@ -524,7 +525,8 @@ namespace Claudable.ViewModels
                 SelectedTabIndex = SelectedTabIndex,
                 Filters = FilterViewModel.Filters.Select(f => f.Value).ToArray(),
                 ProjectRootPath = RootProjectFolder?.FullPath,
-                CurrentFilterMode = CurrentFilterMode
+                CurrentFilterMode = CurrentFilterMode,
+                ExpandedFolders = RootProjectFolder?.GetExpandedPaths() ?? Array.Empty<string>(),
             };
 
             string json = JsonConvert.SerializeObject(state);
@@ -552,7 +554,11 @@ namespace Claudable.ViewModels
                 if (!string.IsNullOrEmpty(state.ProjectRootPath))
                 {
                     LoadProjectStructure(state.ProjectRootPath);
+
+                    if (RootProjectFolder != null)
+                        RootProjectFolder.RestoreExpandedState(state.ExpandedFolders);
                 }
+
                 ApplyFilters();
                 UpdateArtifactStatus();
             }


### PR DESCRIPTION
- Feature: TreeView virtualization to better support large projects
- Feature: Automatic prepend filter with the project root's folder when the filter value starts with \ or /
- Feature: Load and Save project TreeView's folder collapsed/expanded state
- Fix: The TreeView indentation didn't look natural

I've added a Filter class to facilitate improvements to filters in the future.
Project TreeView entries are now collapsed by default.

P.S. Thank you this app is exactly what I was looking for.